### PR TITLE
feat: make config types from a single source of truth

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,9 +30,9 @@
     {
       "name": "getSystemSelection",
       "type": "checkbox",
-      "label": "Get text selection",
       "default": true,
-      "required": false,
+      "required": true,
+      "label": "Read system text selection",
       "description": "Automatically get current text selection and translate"
     },
     {
@@ -920,6 +920,7 @@
           "value": "zu"
         }
       ],
+      "required": false,
       "default": "none"
     },
     {
@@ -1365,6 +1366,7 @@
           "value": "zu"
         }
       ],
+      "required": false,
       "default": "none"
     },
     {
@@ -1810,6 +1812,7 @@
           "value": "zu"
         }
       ],
+      "required": false,
       "default": "none"
     },
     {
@@ -2255,6 +2258,7 @@
           "value": "zu"
         }
       ],
+      "required": false,
       "default": "none"
     },
     {
@@ -2700,6 +2704,7 @@
           "value": "zu"
         }
       ],
+      "required": false,
       "default": "none"
     },
     {
@@ -3145,6 +3150,7 @@
           "value": "zu"
         }
       ],
+      "required": false,
       "default": "none"
     }
   ],

--- a/scripts/preference.ts
+++ b/scripts/preference.ts
@@ -34,6 +34,7 @@ import fs from 'node:fs/promises'
             default: 'en',
           }
         : {
+            required: false,
             default: 'none',
           }),
     }
@@ -44,6 +45,7 @@ import fs from 'node:fs/promises'
       name: 'getSystemSelection',
       type: 'checkbox',
       default: true,
+      required: true,
       label: 'Read system text selection',
       description: 'Automatically get current text selection and translate',
     },

--- a/src/components/Main.tsx
+++ b/src/components/Main.tsx
@@ -5,7 +5,7 @@ import { usePromise } from '@raycast/utils'
 import type { LanguageCode } from '../data/languages'
 import { languagesByCode } from '../data/languages'
 import { translateAll } from '../logic/translator'
-import { useDebouncedValue, useSystemSelection, useTargetLanguages } from '../logic/hooks'
+import { targetLanguages, useDebouncedValue, useSystemSelection } from '../logic/hooks'
 import { unicodeTransform } from '../logic/text'
 import { SpellcheckItem } from './SpellcheckItem'
 import { TranslateDetail } from './TranslateDetail'
@@ -13,7 +13,7 @@ import { TranslateDetail } from './TranslateDetail'
 const langReg = new RegExp(`[>:/](${Object.keys(languagesByCode).join('|')})$`, 'i')
 
 export function Main(): ReactElement {
-  const langs = useTargetLanguages()
+  const langs = targetLanguages
   const [isShowingDetail, setIsShowingDetail] = useState(true)
   const [input, setInput] = useState('')
   const [systemSelection] = useSystemSelection()

--- a/src/components/Main.tsx
+++ b/src/components/Main.tsx
@@ -64,7 +64,7 @@ export function Main(): ReactElement {
         <ActionPanel>
           <Action.OpenInBrowser
             title="Open GitHub"
-            url={'https://github.com/antfu/raycast-multi-translate'}
+            url="https://github.com/antfu/raycast-multi-translate"
             icon={Icon.Code}
           />
         </ActionPanel>
@@ -104,7 +104,6 @@ export function Main(): ReactElement {
                     title="Open in Google Search"
                     url={`https://google.com/?s=${encodeURIComponent(item.original)}`}
                   />
-
                 </ActionPanel.Section>
               </ActionPanel>
             }

--- a/src/logic/hooks.ts
+++ b/src/logic/hooks.ts
@@ -1,28 +1,27 @@
+import { useEffect, useMemo, useState } from 'react'
 import { getPreferenceValues, getSelectedText } from '@raycast/api'
-import React from 'react'
-import type { TranslatePreferences } from '../types'
 import type { LanguageCode } from '../data/languages'
 
 export function usePreferences() {
-  return React.useMemo(() => getPreferenceValues<TranslatePreferences>(), [])
+  return useMemo(() => getPreferenceValues<Preferences.Translate>(), [])
 }
 
 export function useTargetLanguages() {
-  return React.useMemo(() => {
-    const pref = getPreferenceValues<TranslatePreferences>()
+  return useMemo(() => {
+    const pref = getPreferenceValues<Preferences.Translate>()
     const langs = Object.entries(pref)
       .filter(([key]) => key.startsWith('lang'))
       .sort(([key1], [key2]) => key1.localeCompare(key2))
       .map(([_, value]) => value)
-      .filter(i => i && i !== 'none' && i !== 'auto')
+      .filter(i => i && i !== 'none')
     return Array.from(new Set(langs)) as LanguageCode[]
   }, [])
 }
 
 export function useSystemSelection() {
-  const [text, setText] = React.useState('')
+  const [text, setText] = useState('')
   const preferences = usePreferences()
-  React.useEffect(() => {
+  useEffect(() => {
     if (!preferences.getSystemSelection)
       return
 
@@ -43,9 +42,9 @@ export function useSystemSelection() {
 }
 
 export function useDebouncedValue<T>(value: T, delay: number) {
-  const [debouncedValue, setDebouncedValue] = React.useState<T>(value)
+  const [debouncedValue, setDebouncedValue] = useState<T>(value)
 
-  React.useEffect(() => {
+  useEffect(() => {
     const handler = setTimeout(() => {
       setDebouncedValue(value)
     }, delay)

--- a/src/logic/hooks.ts
+++ b/src/logic/hooks.ts
@@ -1,26 +1,22 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { getPreferenceValues, getSelectedText } from '@raycast/api'
 import type { LanguageCode } from '../data/languages'
 
-export function usePreferences() {
-  return useMemo(() => getPreferenceValues<Preferences.Translate>(), [])
-}
+// preferences won't change at runtime.
+export const preferences = getPreferenceValues<Preferences.Translate>()
 
-export function useTargetLanguages() {
-  return useMemo(() => {
-    const pref = getPreferenceValues<Preferences.Translate>()
-    const langs = Object.entries(pref)
-      .filter(([key]) => key.startsWith('lang'))
-      .sort(([key1], [key2]) => key1.localeCompare(key2))
-      .map(([_, value]) => value)
-      .filter(i => i && i !== 'none')
-    return Array.from(new Set(langs)) as LanguageCode[]
-  }, [])
-}
+export const targetLanguages = (() => {
+  const pref = getPreferenceValues<Preferences.Translate>()
+  const langs = Object.entries(pref)
+    .filter(([key]) => key.startsWith('lang'))
+    .sort(([key1], [key2]) => key1.localeCompare(key2))
+    .map(([_, value]) => value)
+    .filter(i => i && i !== 'none')
+  return Array.from(new Set(langs)) as LanguageCode[]
+})()
 
 export function useSystemSelection() {
   const [text, setText] = useState('')
-  const preferences = usePreferences()
   useEffect(() => {
     if (!preferences.getSystemSelection)
       return
@@ -28,7 +24,7 @@ export function useSystemSelection() {
     let isCancelled = false
     getSelectedText()
       .then((cbText) => {
-        if (isCancelled)
+        if (!isCancelled)
           setText((cbText ?? '').trim())
       })
       .catch(() => {})

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,12 +1,3 @@
 import type { LanguageCode } from './data/languages'
 
 export { LanguageCode }
-
-export interface TranslatePreferences {
-  getSystemSelection: boolean
-  lang1: LanguageCode
-  lang2: LanguageCode
-  lang3?: LanguageCode
-  lang4?: LanguageCode
-  lang5?: LanguageCode
-}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
-  "include": ["src/**/*"],
   "compilerOptions": {
     "lib": ["es2020"],
     "module": "commonjs",


### PR DESCRIPTION
### Description

- use perference types from `raycast-env.d.ts`, as it keeps the same type with the real extension config.
- remove hooks usage for getting preferences, because that it won't change at runtime.
- add `required` field, it's declared as _required_ in the JSON schema.

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
